### PR TITLE
Fix: Ghost Identifier

### DIFF
--- a/Records/Processors/ProcessRecordMediaHostedService.cs
+++ b/Records/Processors/ProcessRecordMediaHostedService.cs
@@ -134,7 +134,7 @@ public class ProcessRecordMediaHostedService : BackgroundService
                     continue; // We only care if a run is in the top 5 per player per level
 
                 Result<string> result = await mediaService.UploadGhost(record.Id, ghostData,
-                    $"{record.IdUser}-{record.IdUser}-{Guid.NewGuid()}");
+                    $"{record.IdUser}-{record.IdLevel}-{Guid.NewGuid()}");
 
                 if (result.IsFailed)
                 {


### PR DESCRIPTION
Instead of using the user id twice, swap one for the level id